### PR TITLE
Fix Node.js version for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node index.js"
   },
   "engines": {
-    "node": "8.12.0",
+    "node": "10.x",
     "npm": "*"
   },
   "author": "L375#6740",


### PR DESCRIPTION
This should fix the issue of `} catch {` returning an error, as Node.js versions under 10.3 don't support `} catch {` without an argument; e.g `} catch (e) {`.